### PR TITLE
Misc improvements

### DIFF
--- a/app/views/sessions/_variables.html.erb
+++ b/app/views/sessions/_variables.html.erb
@@ -24,5 +24,5 @@
     <dd><%= request.env['HTTP_USER_AGENT'] || 'nil' %></dd>
 </dl>
 
-<a href='/'>&larr; Login again</a>
+<a href='/login'>&larr; Login again</a>
 

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -2,4 +2,4 @@
   <button type='submit'>Login with Developer</button>
 <% end %>
 
-<p><%= link_to "Sign-in With Ethereum", '/auth/nftauth', method: :post %></p>
+<p><%= link_to "Sign-in With NFTAuth", '/auth/nftauth', method: :post %></p>

--- a/lib/strategies/nftauth.rb
+++ b/lib/strategies/nftauth.rb
@@ -11,7 +11,9 @@ module OmniAuth
 
       info do
         {
-          email: raw_info["email"]
+          email: raw_info["email"],
+          address: raw_info["address"],
+          nfts: raw_info["nfts"],
         }
       end
 


### PR DESCRIPTION
- include user address and nfts in info field
- go to /login instead of root on click "login again"
- rename "sign in with ethereum" to "sign in with nftauth" for clarity, as the demo app is signing in via nftauth service, not via siwe flow directly